### PR TITLE
Fix security bug

### DIFF
--- a/contracts/L2Contract.sol
+++ b/contracts/L2Contract.sol
@@ -17,6 +17,8 @@ contract L2Contract {
     }
 
     function onMessageReceived(address originAddress, uint32 originNetwork, bytes memory data) external payable {
+      // Make sure this function can only be called by the L2 bridge as "originAddess" can be passed an arbitrary value here.
+      require(msg.sender == l2Bridge);
       require(originAddress == l1Contract);
       require(originNetwork == 0);
       caller = originAddress;


### PR DESCRIPTION
Hi @miguelmota, thank you very much for this example. I was doing some research about the zkEVM bridging protocol and this saved me a lot of time.
Anyway, I might be wrong, but I think I spot a security bug in the example and I wanna make sure other people using this as a reference won't make wrong assumptions.

The `L2Contract.sol` implementation sets an `l2Bridge` variable in the constructor, but it's never used. While checking out the `onMessageReceived(...)` function I noticed there's no check to make sure the call is actually from the L2 Bridge.
Relying on the `originAddress` alone is no enough here as any value can be passed by a malicious caller.

I hope this can help.